### PR TITLE
User Docker Container for UI Tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,24 +1,26 @@
-name: 'Interaction and Accessibility Tests'
+name: "Interaction and Accessibility Tests"
 on: push
 jobs:
-  # Run interaction and accessibility tests
-  interaction-and-accessibility:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - name: Install dependencies
-        run: npm install
-      - name: Install Playwright
-        run: npx playwright install --with-deps
-      - name: Build Storybook
-        run: npm run build:storybook --quiet;
-      - name: Serve Storybook and run tests
-        run: |
-          npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
-            "npx http-server storybook-static --port 6006 --silent" \
-            "npx wait-on tcp:6006 && yarn test-storybook"
+    # Run interaction and accessibility tests
+    interaction-and-accessibility:
+        runs-on: ubuntu-latest
+        container:
+            image: mcr.microsoft.com/playwright:v1.46.0-jammy
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+            - name: Install dependencies
+              run: npm install
+            - name: Install Playwright
+              run: npx playwright install --with-deps
+            - name: Build Storybook
+              run: npm run build:storybook --quiet;
+            - name: Serve Storybook and run tests
+              run: |
+                  npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
+                    "npx http-server storybook-static --port 6006 --silent" \
+                    "npx wait-on tcp:6006 && yarn test-storybook"

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -5,7 +5,7 @@ jobs:
     interaction-and-accessibility:
         runs-on: ubuntu-latest
         container:
-            image: mcr.microsoft.com/playwright:v1.46.0-jammy
+            image: mcr.microsoft.com/playwright:v1.45.0-jammy
         steps:
             - uses: actions/checkout@v4
               with:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -15,8 +15,6 @@ jobs:
                   node-version: 20
             - name: Install dependencies
               run: npm install
-            - name: Install Playwright
-              run: npx playwright install --with-deps
             - name: Build Storybook
               run: npm run build:storybook --quiet;
             - name: Serve Storybook and run tests


### PR DESCRIPTION
Using a Docker container rather than freshly installing Playwright browsers translates into around a 50% speedup of the tests, and is probably what we should use going forward to do CI for Storybook tests.