### PR TITLE
Add role protection to sidebar items

### DIFF
--- a/apps/web/app/(sidebar)/layout.tsx
+++ b/apps/web/app/(sidebar)/layout.tsx
@@ -21,7 +21,7 @@ export default async function SidebarLayout({
 			disableTransitionOnChange
 		>
 			<SessionProvider session={session}>
-				<SidebarProvider defaultOpen={false}>
+				<SidebarProvider>
 					<AppSidebar />
 					<main className="w-full">
 						<nav className="flex items-center z-40 sticky top-0 bg-background justify-between border-b mb-2 px-4 py-2">

--- a/apps/web/app/(sidebar)/layout.tsx
+++ b/apps/web/app/(sidebar)/layout.tsx
@@ -2,7 +2,6 @@ import { AppSidebarTrigger, AppSidebar } from "@/components/app-sidebar";
 import { ThemeToggle } from "@/components/app-sidebar/ThemeToggle";
 import { ThemeProvider } from "@/components/theme";
 import { auth } from "@/lib/auth";
-import { Button } from "@repo/ui/components/button";
 import { SidebarProvider } from "@repo/ui/components/sidebar";
 import { SessionProvider } from "next-auth/react";
 

--- a/apps/web/components/app-sidebar/ActiveLink.tsx
+++ b/apps/web/components/app-sidebar/ActiveLink.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+
+export const ActiveLink: React.FC<{ href: string; children: React.ReactNode }> = ({ href, children }) => {
+    const pathname = usePathname();
+    
+    return (
+        <Link className={`${pathname === href ? "bg-accent" : ""} flex items-center space-x-2 p-1.5 rounded-md`} href={href}>
+            {children}
+        </Link>
+    );
+};

--- a/apps/web/components/app-sidebar/AppSidebar.tsx
+++ b/apps/web/components/app-sidebar/AppSidebar.tsx
@@ -22,17 +22,31 @@ import {
 } from "@repo/ui/components/sidebar";
 import { NotepadText, Grid2X2, LogIn, LogOut } from "lucide-react";
 import Link from "next/link";
-// Menu items.
+import { UserRole } from "@repo/database/schema";
+import React from "react";
+
 const navbarData = [
 	{
 		title: "Scout",
+		role: UserRole.USER,
 		items: [{ name: "Stand Form", icon: NotepadText, href: "/scout" }],
 	},
 	{
 		title: "Analysis",
 		items: [{ name: "Team Data Table", icon: Grid2X2, href: "/analysis" }],
 	},
-] as const;
+];
+
+
+type RoleObject = {
+	role?: UserRole;
+} & Record<string, unknown>;
+
+type RoleMapFunction<T extends RoleObject> = (value: T, index: number, array: T[]) => React.ReactNode;
+
+const roleMap = <T extends RoleObject,>(navData: T[], userRole: UserRole | null | undefined, mapFn: RoleMapFunction<T>) => {
+	return navData.map((o, i, a) => !o.role || o.role === userRole ? mapFn(o, i, a) : null);
+}
 
 export async function AppSidebar() {
 	const session = await auth();
@@ -70,12 +84,12 @@ export async function AppSidebar() {
 				</SidebarMenu>
 			</SidebarHeader>
 			<SidebarContent>
-				{navbarData.map((nav) => (
+				{roleMap(navbarData, session?.user.role, (nav) => (
 					<SidebarGroup key={nav.title}>
 						<SidebarGroupLabel>{nav.title}</SidebarGroupLabel>
 						<SidebarGroupContent>
 							<SidebarMenu>
-								{nav.items.map((item) => (
+								{roleMap(nav.items, session?.user.role, (item) => (
 									<SidebarMenuItem key={item.name}>
 										<SidebarMenuButton asChild>
 											<Link href={item.href}>

--- a/apps/web/components/app-sidebar/AppSidebar.tsx
+++ b/apps/web/components/app-sidebar/AppSidebar.tsx
@@ -24,6 +24,7 @@ import { NotepadText, Grid2X2, LogIn, LogOut } from "lucide-react";
 import Link from "next/link";
 import { UserRole } from "@repo/database/schema";
 import React from "react";
+import { ActiveLink } from "./ActiveLink";
 
 const navbarData = [
 	{
@@ -66,7 +67,7 @@ export async function AppSidebar() {
 
 	return (
 		<Sidebar>
-			<SidebarHeader className="p-2">
+			<SidebarHeader>
 				<SidebarMenu>
 					<SidebarMenuItem>
 						<SidebarMenuButton asChild>
@@ -92,10 +93,10 @@ export async function AppSidebar() {
 								{roleMap(nav.items, session?.user.role, (item) => (
 									<SidebarMenuItem key={item.name}>
 										<SidebarMenuButton asChild>
-											<Link href={item.href}>
-												<item.icon />
+											<ActiveLink href={item.href}>
+												<item.icon className="size-4" />
 												<span>{item.name}</span>
-											</Link>
+											</ActiveLink>
 										</SidebarMenuButton>
 									</SidebarMenuItem>
 								))}

--- a/apps/web/components/app-sidebar/AppSidebar.tsx
+++ b/apps/web/components/app-sidebar/AppSidebar.tsx
@@ -25,6 +25,7 @@ import Link from "next/link";
 import { UserRole } from "@repo/database/schema";
 import React from "react";
 import { ActiveLink } from "./ActiveLink";
+import { authorized } from "@/lib/auth/utils";
 
 const navbarData = [
 	{
@@ -45,8 +46,11 @@ type RoleObject = {
 
 type RoleMapFunction<T extends RoleObject> = (value: T, index: number, array: T[]) => React.ReactNode;
 
-const roleMap = <T extends RoleObject,>(navData: T[], userRole: UserRole | null | undefined, mapFn: RoleMapFunction<T>) => {
-	return navData.map((o, i, a) => !o.role || o.role === userRole ? mapFn(o, i, a) : null);
+const roleMap = <T extends RoleObject,>(navData: T[], userRole: UserRole | undefined, mapFn: RoleMapFunction<T>) => {
+	return navData.map((o, i, a) => !o.role || authorized({
+		requiredRole: o.role, 
+		currentUserRole: userRole, 
+	}) ? mapFn(o, i, a) : null);
 }
 
 export async function AppSidebar() {


### PR DESCRIPTION
Make sure that certain actions (like scouting/stand form) only display on sidebar for authenticated users