### PR TITLE
Fix/analytics server script error

### DIFF
--- a/apps/analytics-server/main.py
+++ b/apps/analytics-server/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
-from app.api.spr.router import router as spr_router
-from app.api.tba_ingest.router import router as tba_ingest_router
+from .app.api.spr.router import router as spr_router
+from .app.api.tba_ingest.router import router as tba_ingest_router
 
 app = FastAPI()
 

--- a/apps/analytics-server/package.json
+++ b/apps/analytics-server/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@apps/analytics-server",
     "scripts": {
-        "dev": "uvicorn main:app --reload --host 0.0.0.0 --port 8000",
-        "start": "uvicorn main:app --host 0.0.0.0 --port 8000"
+        "dev": "fastapi dev main.py",
+        "start": "fastapi run main.py"
     }
 }


### PR DESCRIPTION
Fixes two errors encountered when trying to run `turbo dev` in the root dir.
- Fixes package import in `main.py`
- Uses fastapi command instead of uvicorn in the analytics server's `package.json`