### PR TITLE
Make form updates

### DIFF
--- a/apps/web/app/(sidebar)/scout/actions/submitForm.ts
+++ b/apps/web/app/(sidebar)/scout/actions/submitForm.ts
@@ -5,6 +5,7 @@ import { StandFormData, standFormSchema } from "../data/schema";
 import {
 	createServerAction,
 	ServerActionError,
+	ServerActionErrorWithCustomData
 } from "@/lib/actions/actions-utils";
 import { auth } from "@/lib/auth";
 import { AuthErrors, authorized } from "@/lib/auth/utils";
@@ -16,7 +17,9 @@ import {
 	tournament,
 	UserRole,
 } from "@/lib/database/schema";
-import { eq, and } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
+import { _getTeamsInMatch, TeamInMatch } from "./teamsInMatch";
+import { StandFormSubmissionErrors } from "./utils";
 
 /**
  * Get the current tournament
@@ -116,30 +119,21 @@ async function _submitStandForm(data: StandFormData) {
 		throw new ServerActionError(AuthErrors.UNAUTHORIZED);
 	}
 
-	const currentTournament = await getCurrentTournament();
+	const teamMatches = await _getTeamsInMatch(data.match_detail.match_number);
 
-	if (!currentTournament) {
-		throw new ServerActionError("No current tournament set!");
-	}
+	const teamMatchInfo = teamMatches.find(t => t.teamNumber === data.match_detail.team_number);
 
-	const teamMatches = await getTeamMatches(
-		data.match_detail.team_number,
-		data.match_detail.match_number
-	);
-
-	const matchInfo = teamMatches[0];
-
-	if (!matchInfo || !matchInfo.match) {
-		throw new ServerActionError("Team is not in this match");
+	if (!teamMatchInfo || !teamMatchInfo.matchId) {
+		throw new ServerActionErrorWithCustomData(StandFormSubmissionErrors.TEAM_MATCH, teamMatches)
 	}
 
 	await insertStandForm(
 		session.user.id,
-		matchInfo.match.id,
+		teamMatchInfo.matchId,
 		validatedData
 	).catch((err) => {
 		console.error(err);
-		throw new ServerActionError("Failed to insert stand form.");
+		throw new ServerActionError(StandFormSubmissionErrors.FAILURE);
 	});
 }
 
@@ -154,4 +148,4 @@ async function _submitStandForm(data: StandFormData) {
  *
  * @param data The data to submit
  */
-export const submitStandForm = createServerAction(_submitStandForm);
+export const submitStandForm = createServerAction<void, TeamInMatch[], Parameters<typeof _submitStandForm>>(_submitStandForm);

--- a/apps/web/app/(sidebar)/scout/actions/submitForm.ts
+++ b/apps/web/app/(sidebar)/scout/actions/submitForm.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { _getTeamsInMatch, TeamInMatch } from "./teamsInMatch";
+import { StandFormSubmissionErrors } from "./utils";
 import { StandFormData, standFormSchema } from "../data/schema";
 
 import {
@@ -18,8 +20,6 @@ import {
 	UserRole,
 } from "@/lib/database/schema";
 import { and, eq } from "drizzle-orm";
-import { _getTeamsInMatch, TeamInMatch } from "./teamsInMatch";
-import { StandFormSubmissionErrors } from "./utils";
 
 /**
  * Get the current tournament

--- a/apps/web/app/(sidebar)/scout/actions/teamsInMatch.ts
+++ b/apps/web/app/(sidebar)/scout/actions/teamsInMatch.ts
@@ -2,8 +2,8 @@
 
 import { createServerAction } from "@/lib/actions/actions-utils";
 import { db } from "@/lib/database";
-import { match, teamMatch, team, tournament } from "@/lib/database/schema";
-import { eq, and } from "drizzle-orm";
+import { match, team, teamMatch, tournament } from "@/lib/database/schema";
+import { and, eq } from "drizzle-orm";
 
 export type TeamInMatch = {
 	matchId: string | null;
@@ -20,7 +20,7 @@ export type TeamInMatch = {
  * - matchId: The id of the match
  * - teamNumber: The number of the team
  */
-async function _getTeamsInMatch(matchNumber: string): Promise<TeamInMatch[]> {
+export async function _getTeamsInMatch(matchNumber: number): Promise<TeamInMatch[]> {
 	return db
 		.select({
 			matchId: match.id,
@@ -39,7 +39,7 @@ async function _getTeamsInMatch(matchNumber: string): Promise<TeamInMatch[]> {
 		.where(
 			and(
 				eq(tournament.isCurrent, true),
-				eq(match.matchNumber, matchNumber ? parseInt(matchNumber) : 0)
+				eq(match.matchNumber, matchNumber < 0 || isNaN(matchNumber) ? 0 : matchNumber)
 			)
 		);
 }

--- a/apps/web/app/(sidebar)/scout/actions/utils.ts
+++ b/apps/web/app/(sidebar)/scout/actions/utils.ts
@@ -1,0 +1,5 @@
+export enum StandFormSubmissionErrors {
+	NO_CURRENT_TOURNAMENT = "No current tournament set!",
+	TEAM_MATCH = "Team is not in this match!",
+	FAILURE = "Failed to insert stand form."
+}

--- a/apps/web/app/(sidebar)/scout/form/FormNavigation.tsx
+++ b/apps/web/app/(sidebar)/scout/form/FormNavigation.tsx
@@ -37,24 +37,13 @@ export function FormNavigation() {
 			>
 				Previous
 			</Button>
-
-			{isLastStep ? (
-				<Button
-					type="button"
-					onClick={form.handleSubmit(submitForm)}
-					disabled={isSubmitting}
-				>
-					{isSubmitting ? "Submitting..." : "Submit"}
-				</Button>
-			) : (
-				<Button
-					type="button"
-					onClick={goToNextStep}
-					disabled={!canGoNext}
-				>
-					Next
-				</Button>
-			)}
+			<Button
+				type="button"
+				onClick={isLastStep ? form.handleSubmit(submitForm) : goToNextStep}
+				disabled={isLastStep ? isSubmitting : !canGoNext}
+			>
+				{isLastStep ? isSubmitting ? "Submitting..." : "Submit" : "Next"}
+			</Button>
 		</div>
 	);
 }

--- a/apps/web/app/(sidebar)/scout/form/FormNavigation.tsx
+++ b/apps/web/app/(sidebar)/scout/form/FormNavigation.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useFormContext } from "react-hook-form";
 import { useStandForm } from "./FormProvider";
+import { StandFormData } from "../data/schema";
 
 import { Button } from "@repo/ui/components/button";
-import { StandFormData } from "../data/schema";
+import { useFormContext } from "react-hook-form";
 
 /**
  * Navigation component for the stand form

--- a/apps/web/app/(sidebar)/scout/form/FormProvider.tsx
+++ b/apps/web/app/(sidebar)/scout/form/FormProvider.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { submitStandForm } from "../actions/submitForm";
+import { TeamInMatch } from "../actions/teamsInMatch";
+import { StandFormSubmissionErrors } from "../actions/utils";
 import { formMetadata, StandFormData, standFormSchema } from "../data/schema";
 
 import { Cage } from "@/lib/database/schema";
@@ -8,9 +11,6 @@ import { Form } from "@repo/ui/components/form";
 import { useToast } from "@repo/ui/hooks/use-toast";
 import { createContext, Dispatch, SetStateAction, useContext, useState, useTransition } from "react";
 import { FieldErrors, useForm } from "react-hook-form";
-import { submitStandForm } from "../actions/submitForm";
-import { TeamInMatch } from "../actions/teamsInMatch";
-import { StandFormSubmissionErrors } from "../actions/utils";
 
 type ScoutFormContextType = {
 	currentStepIndex: number;

--- a/apps/web/app/(sidebar)/scout/form/StandForm.tsx
+++ b/apps/web/app/(sidebar)/scout/form/StandForm.tsx
@@ -9,12 +9,8 @@ import {
 	TeleopPeriod,
 } from "./steps";
 
-export function StandForm() {
-	const { currentStep } = useStandForm();
-
-	switch (currentStep?.id) {
-		case "match_detail":
-			return <MatchDetail />;
+const nextStep = (name?: string) => {
+	switch (name) {
 		case "auto":
 			return <AutoPeriod />;
 		case "teleop":
@@ -26,4 +22,21 @@ export function StandForm() {
 		default:
 			return null;
 	}
+}
+
+export function StandForm() {
+	const { currentStep } = useStandForm();
+
+	return (
+		<div>
+			<div className={currentStep?.id !== "match_detail" ? "hidden" : ""}>
+				<MatchDetail /> {/* 
+				Don't want match detail component to unmount on render, this will remove team number state if
+				the fallback input for no internet is rendered, and thus will force a subsequent fetch and rerender if a user 
+				decides to check this step again.
+				*/}
+			</div>
+			{nextStep(currentStep?.id)}
+		</div>
+	)
 }

--- a/apps/web/app/(sidebar)/scout/form/steps/MatchDetail.tsx
+++ b/apps/web/app/(sidebar)/scout/form/steps/MatchDetail.tsx
@@ -29,9 +29,7 @@ import { useFormContext } from "react-hook-form";
 import { useStandForm } from "../FormProvider";
 
 const DEFAULT_MATCH_LOAD_WAIT_TIME = 5000;
-function wait(seconds: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
-}
+
 export function MatchDetail() {
 	const form = useFormContext();
 	const { standForm: { teams, setTeams } } = useStandForm();
@@ -78,7 +76,7 @@ export function MatchDetail() {
 				name="match_detail.match_number"
 				render={({ field }) => {
 					const { onChange, ...fieldParams } = field;
-
+					
 					return (
 						<FormItem>
 							<FormLabel>Match Number</FormLabel>

--- a/apps/web/app/(sidebar)/scout/form/steps/MatchDetail.tsx
+++ b/apps/web/app/(sidebar)/scout/form/steps/MatchDetail.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useLoadingTime } from "@/lib/hooks/use-loading-time";
 import { getTeamsInMatch } from "../../actions/teamsInMatch";
+import { useStandForm } from "../FormProvider";
 
+import { useLoadingTime } from "@/lib/hooks/use-loading-time";
 import { useIsOnline } from "@/lib/hooks/use-online-status";
 import { toTitleCase } from "@/lib/utils";
 import { Button } from "@repo/ui/components/button";
@@ -26,7 +27,7 @@ import { Skeleton } from "@repo/ui/components/skeleton";
 import { RefreshCcw } from "lucide-react";
 import { useEffect, useTransition } from "react";
 import { useFormContext } from "react-hook-form";
-import { useStandForm } from "../FormProvider";
+
 
 const DEFAULT_MATCH_LOAD_WAIT_TIME = 5000;
 

--- a/apps/web/app/(sidebar)/scout/form/steps/Miscellaneous.tsx
+++ b/apps/web/app/(sidebar)/scout/form/steps/Miscellaneous.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CardContent } from "@repo/ui/components/card";
-import { FormField, FormItem, FormLabel } from "@repo/ui/components/form";
+import { FormField, FormItem, FormLabel, FormMessage } from "@repo/ui/components/form";
 import {
 	Select,
 	SelectContent,
@@ -53,6 +53,7 @@ export function Miscellaneous() {
 						<FormItem>
 							<FormLabel>Comments</FormLabel>
 							<Textarea {...field} />
+							<FormMessage />
 						</FormItem>
 					)}
 				/>

--- a/apps/web/lib/auth/utils.ts
+++ b/apps/web/lib/auth/utils.ts
@@ -1,6 +1,6 @@
 import { UserRole } from "@/lib/database/schema";
-import { DiscordProfile } from "next-auth/providers/discord";
 import { redirect } from "next/navigation";
+import { DiscordProfile } from "next-auth/providers/discord";
 
 const YETI_GUILD_ID = "408711970305474560";
 const AVALANCHE_GUILD_ID = "1241008226598649886";

--- a/apps/web/lib/hooks/use-loading-time.ts
+++ b/apps/web/lib/hooks/use-loading-time.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef, useState } from "react";
+
+
+export function useLoadingTime(timeToWaitMs: number) {
+    const [loading, setLoading] = useState(false);
+    const [timedOut, setTimedOut] = useState(false);
+
+    const timeoutRef = useRef<NodeJS.Timeout | undefined>();
+
+    useEffect(() => {
+        if (loading && !timeoutRef.current) {
+            timeoutRef.current = setTimeout(() => {
+                setTimedOut(true);
+                setLoading(false);
+            }, timeToWaitMs);
+        } else if (!loading) {
+            clearTimeout(timeoutRef.current)
+            timeoutRef.current = undefined;
+        }
+
+        return () => clearTimeout(timeoutRef.current);
+    }, [loading])
+
+
+    const startLoading = () => {
+        setTimedOut(false);
+        setLoading(true);
+    }
+
+    const stopLoading = () => {
+        setTimedOut(false);
+        setLoading(false);
+    }
+
+    return { timedOut, startLoading, stopLoading };
+}

--- a/apps/web/lib/hooks/use-online-status.ts
+++ b/apps/web/lib/hooks/use-online-status.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 
 function onlineChange(callback: () => void) {
 	window.addEventListener("online", callback);

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -2,3 +2,6 @@ export function getNodeEnv() {
 	return process.env.NODE_ENV;
 }
 
+export function toTitleCase(string: string) {
+	return `${string.charAt(0).toUpperCase()}${string.slice(1)}`;
+}


### PR DESCRIPTION
Form changes 
- Upon changing match numbers, make team number select reset (or pick the team with the same number if they exist in both matches)
- Match number validation - nonnegative or NaN will no longer cause errors
- Toaster - because scouters need to know what happened
- No teams found for this match message when no results are returned 
- Added a timer that checks to see if the loading time exceeds 5 seconds, and provides the user with the prompt to enter team number manually 
- If the user does enter the team number/match manually, make sure that the match/team number they entered was correct and prompt them
- Changed stand form submission code: if a user submits a stand form without internet, it will get a list of all teams in the current match, and then return that list to the user. If the user's manually entered team number was valid, it will submit normally, but if not, it will return to that screen and reprompt the user, with the newly fetched list of teams from submission.
- Merged the submit button from the previous PR into one button. That way even with React updating during each step, the next button will never suddenly become a submit button and cause an accidental submission
