### PR TITLE
feat: create ranking module and integrate with client

### DIFF
--- a/packages/yeti-blue-sdk/src/client/modules/rankings.ts
+++ b/packages/yeti-blue-sdk/src/client/modules/rankings.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import { DistrictRanking, DistrictRankingSchema } from "../../schemas/rankings";
+import { FetcherOptions } from "../../fetcher/types";
+import { Fetcher } from "../../fetcher";
+import { ModuleBase, ModuleBaseConfig } from "./base";
+
+/**
+ * @description A module for interacting with The Blue Alliance Team API
+ *
+ * @see https://www.thebluealliance.com/apidocs/v3
+ */
+export class RankingResource extends ModuleBase<DistrictRanking[]> {
+    private fetcher: Fetcher<DistrictRanking[]>;
+
+    constructor(config: ModuleBaseConfig<DistrictRanking[]>) {
+    super(config);
+    this.fetcher = this.createFetcher(config.baseUrl, config.apiKey);
+    }
+
+    async getDistrictRanking(districtKey: string, options?: FetcherOptions) {
+    const res = await this.fetcher.fetch(
+            `/district/${districtKey}/rankings`,
+            this.getFetcherOptions(options)
+            );
+            return z.array(DistrictRankingSchema).nullable().parseAsync(res.data);
+    }
+}

--- a/packages/yeti-blue-sdk/src/client/yetiBlue.ts
+++ b/packages/yeti-blue-sdk/src/client/yetiBlue.ts
@@ -1,6 +1,7 @@
 import { Cache, MemoryCache } from "../cache";
 import { ModuleBaseConfig } from "./modules/base";
 import { MatchesResource } from "./modules/matches";
+import { RankingResource } from "./modules/rankings";
 import { TeamsResource } from "./modules/team";
 
 interface YetiBlueClientConfig {
@@ -17,6 +18,7 @@ export class YetiBlueClient {
   private readonly defaultCache: boolean;
   teams: TeamsResource;
   matches: MatchesResource;
+  rankings: RankingResource;
 
   constructor(config: YetiBlueClientConfig) {
     this.cache = config.cache || new MemoryCache();
@@ -29,5 +31,6 @@ export class YetiBlueClient {
 
     this.teams = new TeamsResource(resourceConfig);
     this.matches = new MatchesResource(resourceConfig);
+    this.rankings = new RankingResource(resourceConfig);
   }
 }

--- a/packages/yeti-blue-sdk/src/schemas/rankings.ts
+++ b/packages/yeti-blue-sdk/src/schemas/rankings.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const DistrictEventPointsSchema = z.object({
+    district_cmp: z.boolean(),
+    total: z.number().min(0),
+    alliance_points: z.number().min(0),
+    elim_points: z.number().min(0),
+    award_points: z.number().min(0),
+    event_key: z.string(),
+    qual_points: z.number().min(0)
+})
+
+export const DistrictRankingSchema = z.object({
+    team_key: z.string().regex(/^frc\d+$/),
+    rank: z.number().positive(),
+    rookie_bonus: z.number().min(0).optional(),
+    point_total: z.number().min(0),
+    event_points: z.array(DistrictEventPointsSchema).optional()
+})
+
+export type DistrictRanking = z.infer<typeof DistrictRankingSchema>


### PR DESCRIPTION
Introduce a new Ranking module and schema for handling district rankings, and integrate it into the YetiBlue client for enhanced API interactions.